### PR TITLE
Downgrade Django to 2.0.13 to workaround render arguments dismatch issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-modeladmin-reorder==0.3
 django-solo==1.1.3
 django-taggit==0.22.2
 django-widgets-improved==1.5.0
-Django==2.2.10
+Django==2.0.13
 gunicorn==19.7.1
 psycopg2==2.7.7
 social-auth-app-django==2.1.0


### PR DESCRIPTION
Admin 沒辦法新增活動，參考 [這篇](https://stackoverflow.com/questions/52039654/django-typeerror-render-got-an-unexpected-keyword-argument-renderer) 覺得應該是某個 package 壞了，我猜是 django-widgets-improved，但兩年沒更新了有點麻煩，只好先退回 2.0.13。

有空再查吧 QQ